### PR TITLE
Fix deleting next patch; only rename with --backup

### DIFF
--- a/Changes
+++ b/Changes
@@ -40,8 +40,8 @@
     * quit/revert.py:
         - Add missing import for Patch class.
     * quilt/delete.py:
-        - Choose the first patch in "delete_next" rather than complaining no
-          patches are applied
+        - Choose the first unapplied patch in "delete_next" rather than
+          complaining no patches are applied
     * quilt/cli/next.py:
         - Fix default behaviour without any patch argument
     * quilt/cli/previous.py:

--- a/Changes
+++ b/Changes
@@ -39,6 +39,9 @@
         - Fix filenames in the diff header
     * quit/revert.py:
         - Add missing import for Patch class.
+    * quilt/delete.py:
+        - Choose the first patch in "delete_next" rather than complaining no
+          patches are applied
     * quilt/cli/next.py:
         - Fix default behaviour without any patch argument
     * quilt/cli/previous.py:

--- a/quilt/cli/delete.py
+++ b/quilt/cli/delete.py
@@ -41,7 +41,7 @@ class DeleteCommand(Command):
         if args.next:
             delete.delete_next(args.remove, args.backup)
         else:
-            delete.delete_patch(args.patch, args.remove, args.remove)
+            delete.delete_patch(args.patch, args.remove, args.backup)
 
     def deleted_patch(self, patch):
         print("Removed patch %s" % patch.get_name())

--- a/quilt/cli/delete.py
+++ b/quilt/cli/delete.py
@@ -25,7 +25,7 @@ class DeleteCommand(Command):
                             help="Rename the patch file to patch~ rather than "
                             "deleting it. Ignored if not used with `-r'.")
     next = OptionArgument("-n", action="store_true", dest="next",
-                          help="Delete the next patch after topmost, "
+                          help="Delete the next unapplied patch, "
                           "rather than the specified or topmost patch.")
     patch = Argument(nargs="?")
 

--- a/quilt/cli/new.py
+++ b/quilt/cli/new.py
@@ -16,7 +16,7 @@ class NewCommand(Command):
 
     name = "new"
     help = "Create a new patch with the specified file name, and insert it " \
-           "after the topmost patch."
+           "as the next unapplied patch."
 
     patch = Argument("patchname", nargs=1)
 

--- a/quilt/cli/next.py
+++ b/quilt/cli/next.py
@@ -15,7 +15,8 @@ from quilt.patch import Patch
 class NextCommand(Command):
 
     name = "next"
-    help = "Print the name of the next patch after the specified or topmost " \
+    help = "Print the name of the next unapplied patch, " \
+           "or of the patch after the specified " \
            "patch in the series file."
 
     patch = Argument(nargs="?")

--- a/quilt/delete.py
+++ b/quilt/delete.py
@@ -65,9 +65,10 @@ class Delete(Command):
         backup are True a copy of the deleted patch file will be made.
         """
         patch = self.db.top_patch()
-        if not patch:
-            raise NoAppliedPatch(self.db)
-        after = self.db.patch_after(patch)
+        if patch:
+            after = self.db.patch_after(patch)
+        else:
+            after = self.series.first_patch()
         if not after:
             raise QuiltError("No next patch")
 

--- a/quilt/delete.py
+++ b/quilt/delete.py
@@ -60,7 +60,7 @@ class Delete(Command):
         self.deleted_patch(patch)
 
     def delete_next(self, remove=False, backup=False):
-        """ Delete next patch after the topmost applied patch
+        """ Delete next unapplied patch
         If remove is True the patch file will also be removed. If remove and
         backup are True a copy of the deleted patch file will be made.
         """

--- a/quilt/delete.py
+++ b/quilt/delete.py
@@ -66,7 +66,7 @@ class Delete(Command):
         """
         patch = self.db.top_patch()
         if patch:
-            after = self.db.patch_after(patch)
+            after = self.series.patch_after(patch)
         else:
             after = self.series.first_patch()
         if not after:

--- a/quilt/new.py
+++ b/quilt/new.py
@@ -29,7 +29,7 @@ class New(Command):
     def create(self, patchname):
         """ Adds a new patch with patchname to the queue
 
-        The new patch will be added after the top patch
+        The new patch will be added as the next unapplied patch.
         """
         patch = Patch(patchname)
         if self.series.is_patch(patch):

--- a/quilt/patchimport.py
+++ b/quilt/patchimport.py
@@ -34,7 +34,7 @@ class Import(Command):
 
     def import_patch(self, patch_name, new_name=None):
         """ Import patch into the patch queue
-        The patch is inserted after the current top applied patch
+        The patch is inserted as the next unapplied patch.
         """
         if new_name:
             dir_name = os.path.dirname(new_name)

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,4 +1,5 @@
 import os, os.path
+from quilt.db import Db
 from quilt.patch import Patch
 from six.moves import cStringIO
 import sys
@@ -19,6 +20,21 @@ class Test(QuiltTest):
             cmd.delete_next()
             patches.read()
             self.assertTrue(patches.is_empty())
+    
+    def test_next_after(self):
+        """ Delete the successor to the topmost patch """
+        with tmp_series() as [dir, series]:
+            series.add_patch(Patch("topmost"))
+            series.add_patch(Patch("unapplied"))
+            series.save()
+            db = Db(dir)
+            db.add_patch(Patch("topmost"))
+            db.save()
+            cmd = Delete(dir, db.dirname, series.dirname)
+            cmd.delete_next()
+            series.read()
+            [patch] = series.patches()
+            self.assertEqual(patch, Patch("topmost"))
     
     def test_no_backup_next(self):
         """ Remove the next patch without leaving a backup """

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,63 @@
+import os, os.path
+from quilt.patch import Patch
+from six.moves import cStringIO
+import sys
+
+from helpers import QuiltTest, make_file, tmp_mapping, tmp_series
+
+from quilt.delete import Delete
+from quilt.cli.delete import DeleteCommand
+
+class Test(QuiltTest):
+
+    def test_next_first(self):
+        """ Delete the next patch with only unapplied patches """
+        with tmp_series() as [dir, patches]:
+            patches.add_patch(Patch("patch"))
+            patches.save()
+            cmd = Delete(dir, quilt_pc=dir, quilt_patches=patches.dirname)
+            cmd.delete_next()
+            patches.read()
+            self.assertTrue(patches.is_empty())
+    
+    def test_no_backup_next(self):
+        """ Remove the next patch without leaving a backup """
+        with tmp_series() as [dir, patches]:
+            patches.add_patch(Patch("patch"))
+            patches.save()
+            patch = os.path.join(patches.dirname, "patch")
+            make_file(b"", patch)
+            class args:
+                next = True
+                patch = None
+                remove = True
+                backup = False
+            with tmp_mapping(os.environ) as env, \
+                    tmp_mapping(vars(sys)) as tmp_sys:
+                env.set("QUILT_PATCHES", patches.dirname)
+                env.set("QUILT_PC", dir)
+                tmp_sys.set("stdout", cStringIO())
+                DeleteCommand().run(args)
+            self.assertFalse(os.path.exists(patch))
+            self.assertFalse(os.path.exists(patch + "~"))
+    
+    def test_no_backup_named(self):
+        """ Remove a specified patch without leaving a backup """
+        with tmp_series() as [dir, patches]:
+            patches.add_patch(Patch("patch"))
+            patches.save()
+            patch = os.path.join(patches.dirname, "patch")
+            make_file(b"", patch)
+            class args:
+                patch = "patch"
+                next = False
+                remove = True
+                backup = False
+            with tmp_mapping(os.environ) as env, \
+                    tmp_mapping(vars(sys)) as tmp_sys:
+                env.set("QUILT_PATCHES", patches.dirname)
+                env.set("QUILT_PC", dir)
+                tmp_sys.set("stdout", cStringIO())
+                DeleteCommand().run(args)
+            self.assertFalse(os.path.exists(patch))
+            self.assertFalse(os.path.exists(patch + "~"))


### PR DESCRIPTION
This fixes two bugs:

1. “delete -n” had flawed logic to find the first unapplied patch
2. “delete -r” did not remove the patch file, as if “--backup” was specified (recently fixed in one place, but not another)
