### PR TITLE
Fix pushing up to a patch with some already applied

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,6 +35,8 @@
     * quilt/push.py:
         - Allow pushing a patch even if a previous attempt failed
         - Prevent pushing if the topmost patch needs refreshing first
+        - Fix pushing up to a specific patch when some patches are already
+          applied.
         - Keep applied patches list consistent if a patch does not apply but
           prior patches were applied, or "push -f" was used
     * quilt/refresh.py

--- a/quilt/push.py
+++ b/quilt/push.py
@@ -93,7 +93,7 @@ class Push(Command):
         applied = self.db.applied_patches()
         for patch in applied:
             if patch in patches:
-                patches.remove(applied)
+                patches.remove(patch)
 
         if not patches:
             raise AllPatchesApplied(self.series, self.db.top_patch())

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -14,7 +14,7 @@ import six
 from helpers import QuiltTest, make_file, tmp_series
 
 from quilt.db import Db
-from quilt.error import QuiltError
+from quilt.error import QuiltError, AllPatchesApplied
 from quilt.patch import Patch
 from quilt.push import Push
 from quilt.utils import Directory, TmpDirectory, File
@@ -86,6 +86,14 @@ class PushTest(QuiltTest):
 
             self.assertTrue(f1.exists())
             self.assertTrue(f2.exists())
+    
+    def test_upto_applied(self):
+        """ Push up to a specified patch when a patch is already applied """
+        top = os.path.join(test_dir, "data", "pop", "test1")
+        pc = os.path.join(top, "pc")
+        patches = os.path.join(top, "patches")
+        cmd = Push(top, pc, patches)
+        self.assertRaises(AllPatchesApplied, cmd.apply_patch, "p1.patch")
     
     def test_force(self):
         with tmp_series() as [dir, series]:


### PR DESCRIPTION
The wrong variable was being removed from the list of patches to apply. Example error that this fixes:

``` Shell session
$ pquilt new p1
$ pquilt push p1  # Nothing applied → p1 applied
Applying patch p1
Now at patch p1
$ pquilt new p2
$ pquilt push p2  # Should leave p1 applied and apply p2
Traceback (most recent call last):
  File "/home/proj/quilt/python-quilt/pquilt", line 26, in <module>
    main()
  File "/home/proj/quilt/python-quilt/pquilt", line 20, in main
    cli.run()
  File "/home/proj/quilt/python-quilt/quilt/cli/meta.py", line 115, in run
    args.run(args)
  File "/home/proj/quilt/python-quilt/quilt/cli/push.py", line 35, in run
    push.apply_patch(args.patch, args.force)
  File "/home/proj/quilt/python-quilt/quilt/push.py", line 96, in apply_patch
    patches.remove(applied)
ValueError: list.remove(x): x not in list
[Exit 1]
```
