### PR TITLE
Support series -v

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,7 @@
         - Added new PatchAlreadyExists error class
     * quilt/cli:
         - Replaced optparse with argparse.
+        - Add "series -v" option.
 
     BUGFIXES
     * quilt/db.py:

--- a/quilt/cli/parser.py
+++ b/quilt/cli/parser.py
@@ -134,7 +134,7 @@ class ArgumentsCollectorMetaClass(type):
 class ArgumentGroup(object):
 
     """
-    A class to declarative define argument groups at a class
+    A class to declare argument groups at a class
 
     Usage:
         class MyParser(Parser):
@@ -251,7 +251,7 @@ class SubParserGroup(object):
 class Argument(object):
 
     """
-    A class to declarative define positional arguments at a class
+    A class to declare positional arguments at a class
 
     Usage:
         class MyParser(Parser):
@@ -310,7 +310,7 @@ class Argument(object):
 class OptionArgument(Argument):
 
     """
-    A class to declarative define (optional) arguments at a class
+    A class to declare (optional) arguments at a class
 
     Usage:
         class MyParser(Parser):
@@ -319,6 +319,12 @@ class OptionArgument(Argument):
             arg2 = OptionArgument(type=int)
             arg3 = OptionArgument(nargs=2)
             arg4 = OptionArgument(required=True)
+    
+    By default, the option name is taken from the attribute name and prefixed
+    with two dashes, or one dash if the name is a single character:
+    
+    verbose = OptionArgument(action="store_true")  # usage: [--verbose]
+    v = OptionArgument(action="store_true")  # usage: [-v]
     """
 
     prefix_chars = "--"
@@ -326,7 +332,10 @@ class OptionArgument(Argument):
     def _get_args(self):
         args = self.args
         if not args:
-            args = (self.prefix_chars + self.name,)
+            if self.prefix_chars == "--" and len(self.name) == 1:
+                args = ("-" + self.name,)
+            else:
+                args = (self.prefix_chars + self.name,)
         return args
 
 

--- a/quilt/cli/series.py
+++ b/quilt/cli/series.py
@@ -7,7 +7,8 @@
 # See LICENSE comming with the source of python-quilt for details.
 
 from quilt.cli.meta import Command
-from quilt.db import Series
+from quilt.cli.parser import OptionArgument
+from quilt.db import Db, Series
 
 
 class SeriesCommand(Command):
@@ -15,7 +16,22 @@ class SeriesCommand(Command):
     name = "series"
     help = "Print the names of all patches in the series file."
 
+    v = OptionArgument(action="store_true", help="""indicate applied (+)
+        and topmost (=) patches""")
+
     def run(self, args):
         series = Series(self.get_patches_dir())
-        for patch in series.patches():
-            print(patch)
+        if args.v:
+            applied = Db(self.get_pc_dir()).patches()
+            for patch in applied[:-1]:
+                print("+ " + patch.get_name())
+            if applied:
+                print("= " + applied[-1].get_name())
+                patches = series.patches_after(applied[-1])
+            else:
+                patches = series.patches()
+            for patch in patches:
+                print("  " + patch.get_name())
+        else:
+            for patch in series.patches():
+                print(patch.get_name())

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -12,6 +12,8 @@ from contextlib import contextmanager
 import os, os.path
 from quilt.db import Series
 from quilt.utils import TmpDirectory
+from six.moves import cStringIO
+import sys
 import unittest
 
 
@@ -36,6 +38,17 @@ def tmp_series():
         patches = os.path.join(dir.get_name(), "patches")
         os.mkdir(patches)
         yield (dir.get_name(), Series(patches))
+
+
+def run_cli(command_cls, args, patches, applied):
+    with tmp_mapping(os.environ) as env, \
+            tmp_mapping(vars(sys)) as tmp_sys:
+        env.set("QUILT_PATCHES", patches)
+        env.set("QUILT_PC", applied)
+        tmp_sys.set("stdout", cStringIO())
+        args = type("args", (), args)
+        command_cls().run(args)
+        return sys.stdout.getvalue()
 
 
 class tmp_mapping:

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,10 +1,8 @@
-import os, os.path
+import os.path
 from quilt.db import Db
 from quilt.patch import Patch
-from six.moves import cStringIO
-import sys
 
-from helpers import QuiltTest, make_file, tmp_mapping, tmp_series
+from helpers import QuiltTest, make_file, run_cli, tmp_series
 
 from quilt.delete import Delete
 from quilt.cli.delete import DeleteCommand
@@ -43,17 +41,9 @@ class Test(QuiltTest):
             patches.save()
             patch = os.path.join(patches.dirname, "patch")
             make_file(b"", patch)
-            class args:
-                next = True
-                patch = None
-                remove = True
-                backup = False
-            with tmp_mapping(os.environ) as env, \
-                    tmp_mapping(vars(sys)) as tmp_sys:
-                env.set("QUILT_PATCHES", patches.dirname)
-                env.set("QUILT_PC", dir)
-                tmp_sys.set("stdout", cStringIO())
-                DeleteCommand().run(args)
+            run_cli(DeleteCommand,
+                dict(next=True, patch=None, remove=True, backup=False),
+                patches.dirname, applied=dir)
             self.assertFalse(os.path.exists(patch))
             self.assertFalse(os.path.exists(patch + "~"))
     
@@ -64,16 +54,8 @@ class Test(QuiltTest):
             patches.save()
             patch = os.path.join(patches.dirname, "patch")
             make_file(b"", patch)
-            class args:
-                patch = "patch"
-                next = False
-                remove = True
-                backup = False
-            with tmp_mapping(os.environ) as env, \
-                    tmp_mapping(vars(sys)) as tmp_sys:
-                env.set("QUILT_PATCHES", patches.dirname)
-                env.set("QUILT_PC", dir)
-                tmp_sys.set("stdout", cStringIO())
-                DeleteCommand().run(args)
+            run_cli(DeleteCommand,
+                dict(patch="patch", next=False, remove=True, backup=False),
+                patches.dirname, applied=dir)
             self.assertFalse(os.path.exists(patch))
             self.assertFalse(os.path.exists(patch + "~"))

--- a/tests/test_patch_lists.py
+++ b/tests/test_patch_lists.py
@@ -6,50 +6,56 @@
 
 """ Test operations that list patches """
 
-import os
 import os.path
 import sys
 
-from contextlib import contextmanager
 from unittest import TestCase
 
+from quilt.db import Db
+from quilt.patch import Patch
 from six.moves import cStringIO
 
-from helpers import tmp_mapping
+from helpers import run_cli, tmp_mapping, tmp_series
 
 from quilt.cli.next import NextCommand
 from quilt.cli.previous import PreviousCommand
-
-
-class C(object):
-    patch = None
+from quilt.cli.series import SeriesCommand
 
 
 class Test(TestCase):
 
     def test_previous_only_unapplied(self):
-        with self._setup_test_data(), \
-                tmp_mapping(vars(sys)) as tmp_sys:
+        env = self._setup_test_data()
+        with tmp_mapping(vars(sys)) as tmp_sys:
             tmp_sys.set("stderr", cStringIO())
             with self.assertRaises(SystemExit) as caught:
-                PreviousCommand().run(C())
+                run_cli(PreviousCommand, dict(patch=None), *env)
             self.assertEqual(caught.exception.code, 1)
             self.assertIn("No patches applied", sys.stderr.getvalue())
 
     def test_next_topmost(self):
-        with self._setup_test_data(), \
-                tmp_mapping(vars(sys)) as tmp_sys:
-            tmp_sys.set("stdout", cStringIO())
-            NextCommand().run(C())
-            self.assertEqual("p1.patch\n", sys.stdout.getvalue())
+        env = self._setup_test_data()
+        output = run_cli(NextCommand, dict(patch=None), *env)
+        self.assertEqual("p1.patch\n", output)
 
-    @contextmanager
     def _setup_test_data(self):
         data = os.path.join(os.path.dirname(__file__), "data")
         patches = os.path.join(data, "push", "test2", "patches")
         no_applied = os.path.join(data, "push", "test2")
+        return (patches, no_applied)
 
-        with tmp_mapping(os.environ) as env:
-            env.set("QUILT_PATCHES", patches)
-            env.set("QUILT_PC", no_applied)
-            yield
+    def test_series_v(self):
+        with tmp_series() as [dir, series]:
+            applied = Db(dir)
+            applied.add_patch(Patch("applied.patch"))
+            applied.add_patch(Patch("topmost.patch"))
+            applied.save()
+            series.add_patches(applied.applied_patches())
+            series.add_patch(Patch("unapplied.patch"))
+            series.save()
+            output = run_cli(SeriesCommand, dict(v=True),
+                series.dirname, applied.dirname)
+        self.assertMultiLineEqual(output,
+            "+ applied.patch\n"
+            "= topmost.patch\n"
+            "  unapplied.patch\n")


### PR DESCRIPTION
I also extended the _argparse_ wrapper to infer a single-dash option like “-v” when the option name is a single character, and factored out a helper function to test CLI commands.